### PR TITLE
Cfgletter indices and nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "Flake for the cfg-fuzzer program";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      formatter = forEachSystem (pkgs: pkgs.nixfmt);
+
+      devShells = forEachSystem (pkgs: {
+        default = pkgs.callPackage (
+          {
+            mkShellNoCC,
+            cargo,
+          }:
+          mkShellNoCC {
+            strictDeps = true;
+            packages = [
+              cargo
+            ];
+          }
+        ) { };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -22,16 +22,18 @@
       devShells = forEachSystem (pkgs: {
         default = pkgs.callPackage (
           {
-            mkShellNoCC,
+            mkShell,
             cargo,
+            rustc,
           }:
-          mkShellNoCC {
+          mkShell {
             strictDeps = true;
             packages = [
               cargo
+              rustc
             ];
           }
-        ) { };
+        ) { mkShell = pkgs.mkShell.override { inherit (pkgs.llvmPackages) stdenv; }; };
       });
     };
 }

--- a/src/bin/cfgfuzz.rs
+++ b/src/bin/cfgfuzz.rs
@@ -23,7 +23,7 @@ fn main() -> std::io::Result<()> {
         }
     };
 
-    let ast = match parse(&src, &args.grammar, &args.terms.into_boxed_slice()) {
+    let ast = match parse(&src, &args.grammar, &args.terms.into_boxed_slice(), &args.start) {
         Ok(ast) => ast,
         Err(e) => {
             eprintln!("{}err{}: {}", RED, CLEAR, e);
@@ -31,7 +31,7 @@ fn main() -> std::io::Result<()> {
         }
     };
 
-    let generated = match generate_code(ast, &args.start, &mut rand::rng()) {
+    let generated = match generate_code(ast, &mut rand::rng()) {
         Ok(g) => g,
         Err(e) => {
             eprintln!("{}err{}: {}", RED, CLEAR, e);

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -2,28 +2,46 @@ use std::{collections::HashMap, fmt::Display};
 
 #[derive(Clone, Debug)]
 pub struct Cfg {
-    pub rules: HashMap<Box<str>, CfgRule>,
+    letters: Box<[CfgLetter]>,
+    pub top_level: CfgRule,
     pub terms: HashMap<Box<str>, CfgRule>,
 }
 
-pub type CfgRule = Box<[CfgLetter]>;
+impl Cfg {
+    pub fn new(letters: Box<[CfgLetter]>, top_level: CfgRule, terms: HashMap<Box<str>, CfgRule>) -> Self {
+        Cfg { letters, top_level, terms }
+    }
+
+    /// Get the slice of letters, which `rule` refers to.
+    pub fn rule_slice(&self, rule: &CfgRule) -> &[CfgLetter] {
+        &self.letters[rule.0 .. rule.1]
+    }
+
+    pub fn get_letter(&self, id: usize) -> &CfgLetter {
+        &self.letters[id]
+    }
+}
+
+/// A grouped list of letters
+pub type CfgRule = (usize, usize);
+pub type CfgTermID = u16;
 
 #[derive(Clone, Debug)]
 pub enum CfgLetter {
     /// A reference to another rule
-    Rule(Box<str>),
+    Rule(CfgRule),
     /// String literal
     StrLit(Box<str>),
     /// A chain of options, where only one will be evaluated, denoted by the | operator
-    Or(Box<[Box<[CfgLetter]>]>),
+    Or(Box<[CfgRule]>),
     /// An optional letter, denoted by the ? suffix
-    Optional(Box<CfgLetter>),
+    Optional(usize),
     /// An arbitrary amount of repitions, denoted by the * suffix
-    Many(Box<CfgLetter>),
+    Many(usize),
     /// An arbitrary amount of repitions, denoted by the + suffix
-    OneOrMore(Box<CfgLetter>),
+    OneOrMore(usize),
     /// A group of letters, denoted by surrounding it in ( )
-    Group(Box<[CfgLetter]>),
+    Group(CfgRule),
     Range(Box<[CfgRange]>),
     /// A terminating value
     Term(Box<str>),

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -3,30 +3,20 @@ use thiserror::Error;
 
 use crate::cfg::{Cfg, CfgLetter};
 
+// TODO: Remove GenerateError, as Terms should also be parsed properly in the parser
 #[derive(Error, Debug)]
 pub enum GenerateError {
-    #[error("Encountered unknown rule '{0}'")]
-    UnknownRule(Box<str>),
-    #[error(
-        "Unknown starting rule '{0}'. The starting rule needs to be declared as any other rule."
-    )]
-    UnknownStart(Box<str>),
     #[error("Unknown term '{0}'. You can define it with -T=\"{0}:RULE\"")]
     UnknownTerm(Box<str>),
 }
 
 pub fn generate_code(
     cfg: Cfg,
-    start: &str,
     rng: &mut dyn rand::Rng,
 ) -> Result<Box<str>, GenerateError> {
     let mut code = String::new();
 
-    let Some(rule) = cfg.rules.get(start) else {
-        return Err(GenerateError::UnknownStart(start.into()));
-    };
-
-    for r in rule {
+    for r in cfg.rule_slice(&cfg.top_level) {
         generate_from_letter(&cfg, r, &mut code, rng)?;
     }
 
@@ -40,11 +30,8 @@ fn generate_from_letter(
     rng: &mut dyn rand::Rng,
 ) -> Result<(), GenerateError> {
     match ltr {
-        CfgLetter::Rule(ident) => {
-            let Some(rule) = cfg.rules.get(ident) else {
-                return Err(GenerateError::UnknownRule(ident.clone()));
-            };
-            for r in rule {
+        CfgLetter::Rule(rule) => {
+            for r in cfg.rule_slice(rule) {
                 generate_from_letter(cfg, r, out, rng)?;
             }
         }
@@ -57,29 +44,29 @@ fn generate_from_letter(
                 return Ok(());
             };
 
-            for r in rule {
+            for r in cfg.rule_slice(rule) {
                 generate_from_letter(cfg, r, out, rng)?;
             }
         }
-        CfgLetter::Optional(cfg_letter) => {
+        CfgLetter::Optional(id) => {
             if rng.random_bool(0.50) {
-                generate_from_letter(cfg, cfg_letter, out, rng)?;
+                generate_from_letter(cfg, cfg.get_letter(*id), out, rng)?;
             }
         }
-        CfgLetter::Many(cfg_letter) => {
+        CfgLetter::Many(id) => {
             while rng.random_bool(0.50) {
-                generate_from_letter(cfg, cfg_letter, out, rng)?;
+                generate_from_letter(cfg, cfg.get_letter(*id), out, rng)?;
             }
         }
-        CfgLetter::OneOrMore(cfg_letter) => {
-            generate_from_letter(cfg, cfg_letter, out, rng)?;
+        CfgLetter::OneOrMore(id) => {
+            generate_from_letter(cfg, cfg.get_letter(*id), out, rng)?;
 
             while rng.random_bool(0.50) {
-                generate_from_letter(cfg, cfg_letter, out, rng)?;
+                generate_from_letter(cfg, cfg.get_letter(*id), out, rng)?;
             }
         }
-        CfgLetter::Group(letters) => {
-            for ltr in letters {
+        CfgLetter::Group(group) => {
+            for ltr in cfg.rule_slice(group) {
                 generate_from_letter(cfg, ltr, out, rng)?;
             }
         }
@@ -100,7 +87,7 @@ fn generate_from_letter(
         }
         CfgLetter::Term(term) => {
             if let Some(term_rule) = cfg.terms.get(term) {
-                for r in term_rule {
+                for r in cfg.rule_slice(term_rule) {
                     generate_from_letter(cfg, r, out, rng)?;
                 }
                 return Ok(());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,6 +9,10 @@ use crate::{
 
 #[derive(Error, Debug)]
 pub enum ParseError {
+    #[error("Top level declaration not found, no rule with name '{0}'")]
+    NoTopLevelDeclaration(Box<str>),
+    #[error("Rule {0} referenced but not defined")]
+    UndefinedRule(Box<str>),
     #[error("{0} -> Expected {1} but got {2:?}")]
     UnexpectedToken(LexerCtx, Box<str>, Token),
     #[error("{0} -> Got unexpected operator {1:?}")]
@@ -27,10 +31,43 @@ pub enum ParseError {
     GotEof(LexerCtx),
 }
 
-pub fn parse(src: &str, filename: &str, terms: &[Box<str>]) -> Result<Cfg, ParseError> {
-    let mut lex = Lexer::new(src, filename);
+use MaybeUnknown::*;
+enum MaybeUnknown {
+    /// The letter is known
+    Known(CfgLetter),
+    /// The letter is a reference to another rule, which must be retrieved later
+    Unknown(Box<str>),
+}
 
-    let mut map = HashMap::new();
+impl MaybeUnknown {
+    /// Tries to become a known rule.
+    /// Returns `Some` if value is known, or found in `map`.
+    /// Returns `None` if value is unknown and not found in `map`
+    ///
+    /// If the value was fetched from the map, the result will always have variant
+    /// `CfgLetter::Rule`
+    pub fn into_letter(self, map: &HashMap<Box<str>, CfgRule>) -> Result<CfgLetter, ParseError> {
+        match self {
+            Known(l) => Ok(l),
+            Unknown(name) => map
+                .get(&name)
+                .map(|rule| CfgLetter::Rule(*rule))
+                .ok_or(ParseError::UndefinedRule(name)),
+        }
+    }
+}
+
+pub fn parse(
+    src: &str,
+    filename: &str,
+    terms: &[Box<str>],
+    top_level: &str,
+) -> Result<Cfg, ParseError> {
+    let mut lex = Lexer::new(src, filename);
+    let mut maybes: Vec<MaybeUnknown> = vec![];
+
+    // All CfgRules with names attached for reference
+    let mut map: HashMap<Box<str>, CfgRule> = HashMap::new();
 
     while let Some(tok) = lex.next() {
         let ident = match tok {
@@ -53,14 +90,15 @@ pub fn parse(src: &str, filename: &str, terms: &[Box<str>]) -> Result<Cfg, Parse
         }
 
         if matches!(lex.peek_next(), Some(Token::Op(Operator::Pipe))) {
-            let _ = lex.next();
+            _ = lex.next();
         }
 
-        let rules = parse_rule(&mut lex)?;
-        map.insert(ident.clone(), rules.unwrap());
+        let rules = parse_rule(&mut lex, &mut maybes)?;
+
+        map.insert(ident.clone(), rules);
     }
 
-    let mut terms_map = HashMap::new();
+    let mut terms_map: HashMap<Box<str>, (usize, usize)> = HashMap::new();
     for term in terms {
         let Some((term_ident, term_str)) = term.split_once(':') else {
             return Err(ParseError::InvalidTerm(term.clone()));
@@ -68,40 +106,48 @@ pub fn parse(src: &str, filename: &str, terms: &[Box<str>]) -> Result<Cfg, Parse
 
         let mut lex = Lexer::new(term_str, term_ident);
 
-        let Some(term_rule) = parse_rule(&mut lex)? else {
-            return Err(ParseError::InvalidTerm(term.clone()));
-        };
+        let term_rule = parse_rule(&mut lex, &mut maybes)?;
 
-        for ltr in &term_rule {
-            if !is_valid_term(ltr) {
+        for id in term_rule.0..term_rule.1 {
+            if !is_valid_term(id, &maybes) {
                 return Err(ParseError::TermRecurse(term_ident.into()));
             }
         }
 
-        if terms_map.insert(term_ident.into(), term_rule).is_some() {
+        if terms_map.contains_key(term_ident) {
             return Err(ParseError::TermDupe(term_ident.into()));
-        };
+        }
+
+        let begin = maybes.len();
+        terms_map.insert(term_ident.into(), (begin, maybes.len()));
     }
 
-    Ok(Cfg {
-        rules: map,
-        terms: terms_map,
-    })
+    let tld_rule_pos = match map.get(top_level) {
+        Some(rule_pos) => *rule_pos,
+        None => return Err(ParseError::NoTopLevelDeclaration(top_level.into())),
+    };
+
+    let letters: Result<Box<[CfgLetter]>, ParseError> = maybes
+        .into_iter()
+        .map(|maybe| maybe.into_letter(&map))
+        .collect();
+
+    Ok(Cfg::new(letters?, tld_rule_pos, terms_map))
 }
 
-fn parse_rule(lex: &mut Lexer) -> Result<Option<CfgRule>, ParseError> {
-    let mut letters = vec![];
+fn parse_rule(lex: &mut Lexer, letters: &mut Vec<MaybeUnknown>) -> Result<CfgRule, ParseError> {
     let mut ors = vec![];
+    let mut begin = letters.len();
     loop {
         // Unwrap because we know its not None due to last match
         if matches!(lex.peek_next(), Some(Token::Op(Operator::Eol))) {
-            _ = lex.next();
+            lex.next();
             break;
         }
-        match parse_letter(lex)? {
-            Some(CfgLetter::Or(or)) => {
-                letters.push(or[0][0].clone());
-                ors.push(std::mem::take(&mut letters).into());
+        match parse_letter(lex, letters)? {
+            Some(Known(CfgLetter::Or(..))) => {
+                ors.push((begin, letters.len()));
+                begin = letters.len();
             }
             Some(ltr) => letters.push(ltr),
             None => break,
@@ -109,58 +155,64 @@ fn parse_rule(lex: &mut Lexer) -> Result<Option<CfgRule>, ParseError> {
     }
 
     if !ors.is_empty() {
-        ors.push(std::mem::take(&mut letters).into());
-        letters.push(CfgLetter::Or(ors.into()))
+        ors.push((begin, letters.len()));
+        begin = letters.len();
+        letters.push(Known(CfgLetter::Or(ors.into())))
     }
 
-    Ok(Some(letters.into()))
+    Ok((begin, letters.len()))
 }
 
-fn parse_letter(lex: &mut Lexer) -> Result<Option<CfgLetter>, ParseError> {
-    match lex.peek_next() {
-        Some(_) => {}
-        // None => return Err(ParseError::GotEof(lex.ctx.clone())),
-        None => return Ok(None),
-    }
+fn parse_letter(
+    lex: &mut Lexer,
+    letters: &mut Vec<MaybeUnknown>,
+) -> Result<Option<MaybeUnknown>, ParseError> {
+    // match lex.peek_next() {
+    //     Some(_) => {}
+    //     // None => return Err(ParseError::GotEof(lex.ctx.clone())),
+    //     None => return Ok(None),
+    // }
 
     let mut letter = match lex.next() {
         Some(Token::Ident(ident)) => {
             if is_uppercase(&ident) {
-                CfgLetter::Term(ident)
+                Known(CfgLetter::Term(ident))
             } else {
-                CfgLetter::Rule(ident)
+                Unknown(ident)
             }
         }
         Some(Token::Op(op)) => match op {
+            Operator::Pipe => Known(CfgLetter::Or(Box::new([]))),
             Operator::OpenParen => {
-                let mut letters = vec![];
+                let mut begin = letters.len();
                 let mut ors = vec![];
                 loop {
                     match lex.peek_next() {
                         Some(Token::Op(Operator::CloseParen)) => {
-                            let _ = lex.next();
+                            lex.next();
                             break;
                         }
                         None => return Err(ParseError::GotEof(lex.ctx.clone())),
                         _ => {}
                     }
 
-                    match parse_letter(lex)? {
-                        Some(CfgLetter::Or(or)) => {
-                            letters.push(or[0][0].clone());
-                            ors.push(std::mem::take(&mut letters).into());
+                    match parse_letter(lex, letters)? {
+                        Some(Known(CfgLetter::Or(..))) => {
+                            ors.push((begin, letters.len()));
+                            begin = letters.len();
                         }
                         Some(ltr) => letters.push(ltr),
                         None => return Err(ParseError::GotEof(lex.ctx.clone())),
                     }
                 }
 
-                if ors.is_empty() {
-                    CfgLetter::Group(letters.into())
-                } else {
-                    ors.push(std::mem::take(&mut letters).into());
-                    CfgLetter::Group([CfgLetter::Or(ors.into())].into())
+                if !ors.is_empty() {
+                    ors.push((begin, letters.len()));
+                    begin = letters.len();
+                    letters.push(Known(CfgLetter::Or(ors.into())))
                 }
+
+                Known(CfgLetter::Group((begin, letters.len())))
             }
             Operator::OpenRange => {
                 let mut ranges = vec![];
@@ -228,33 +280,34 @@ fn parse_letter(lex: &mut Lexer) -> Result<Option<CfgLetter>, ParseError> {
                     ranges.push(CfgRange::new_single(ch))
                 }
 
-                CfgLetter::Range(ranges.into())
+                Known(CfgLetter::Range(ranges.into()))
             }
             _ => return Err(ParseError::UnexpectedOp(lex.ctx.clone(), op)),
         },
-        Some(Token::String(str)) => CfgLetter::StrLit(str),
-        Some(Token::Num(num)) => CfgLetter::StrLit(num.to_string().into()),
+        Some(Token::String(str)) => Known(CfgLetter::StrLit(str)),
+        Some(Token::Num(num)) => Known(CfgLetter::StrLit(num.to_string().into())),
         None => return Ok(None),
     };
 
     while let Some(Token::Op(op)) = lex.peek_next() {
         match op {
             Operator::Star => {
-                let _ = lex.next();
-                letter = CfgLetter::Many(Box::new(letter))
+                lex.next();
+                let idx = letters.len();
+                letters.push(letter);
+                letter = Known(CfgLetter::Many(idx))
             }
             Operator::Plus => {
-                let _ = lex.next();
-                letter = CfgLetter::OneOrMore(Box::new(letter))
+                lex.next();
+                let idx = letters.len();
+                letters.push(letter);
+                letter = Known(CfgLetter::OneOrMore(idx))
             }
             Operator::QuestionMark => {
-                let _ = lex.next();
-                letter = CfgLetter::Optional(Box::new(letter))
-            }
-            Operator::Pipe => {
-                let _ = lex.next();
-                letter = CfgLetter::Or(Box::new([Box::new([letter])]));
-                break;
+                lex.next();
+                let idx = letters.len();
+                letters.push(letter);
+                letter = Known(CfgLetter::Optional(idx))
             }
             Operator::Eol
             | Operator::RuleDeclare
@@ -262,6 +315,7 @@ fn parse_letter(lex: &mut Lexer) -> Result<Option<CfgLetter>, ParseError> {
             | Operator::CloseParen
             | Operator::OpenRange
             | Operator::CloseRange
+            | Operator::Pipe
             | Operator::RangeTo => {
                 break;
             }
@@ -280,32 +334,22 @@ fn is_uppercase(str: &str) -> bool {
     true
 }
 
-fn is_valid_term(letter: &CfgLetter) -> bool {
+fn is_valid_term(id: usize, maybes: &Vec<MaybeUnknown>) -> bool {
+    let Known(letter) = &maybes[id] else {
+        return false;
+    };
     match letter {
         CfgLetter::Rule(_) | CfgLetter::Term(_) => false,
         CfgLetter::StrLit(_) => true,
-        CfgLetter::Or(items) => {
-            for rule in items {
-                for ltr in rule {
-                    if !is_valid_term(ltr) {
-                        return false;
-                    }
-                }
-            }
-            true
-        }
-        CfgLetter::Optional(ltr) => is_valid_term(ltr),
+        CfgLetter::Or(items) => items
+            .iter()
+            .flat_map(|rule| rule.0..rule.1)
+            .all(|maybe| is_valid_term(maybe, maybes)),
 
-        CfgLetter::Many(ltr) => is_valid_term(ltr),
-        CfgLetter::OneOrMore(ltr) => is_valid_term(ltr),
-        CfgLetter::Group(items) => {
-            for ltr in items {
-                if !is_valid_term(ltr) {
-                    return false;
-                }
-            }
-            true
-        }
+        CfgLetter::Optional(id) => is_valid_term(*id, maybes),
+        CfgLetter::Many(id) => is_valid_term(*id, maybes),
+        CfgLetter::OneOrMore(id) => is_valid_term(*id, maybes),
+        CfgLetter::Group(items) => (items.0..items.1).all(|maybe| is_valid_term(maybe, maybes)),
         CfgLetter::Range(_) => true,
     }
 }


### PR DESCRIPTION
Changed the `CfgLetter` enum to use indicies instead of `Box`s of other letters and hashmap keys.
- Improves performance by turning the `CfgLetters` into an array tree.
- Moves some errors earlier into the pipeline. (`UnknownRule` and `UnknownStart`)

Terms are left as keys and a HashMap, as they rely on their name later in the pipeline.